### PR TITLE
Sass depreciation warning fix

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,11 @@ import react from '@vitejs/plugin-react-swc'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler' // sass fix for incoming update
+      }
+    }
+  }
 })


### PR DESCRIPTION
- Updated vite config to use the modern-compilier when dealing with sass (By default it uses the legacy api which is now going to be depreciated with Sass' next big update)
- This should remove the string of warning messages when we all run `npm run dev`